### PR TITLE
Refine agent cockpit drawer for store and tree views

### DIFF
--- a/apps/web/src/agent/AgentInsightWorkbench.tsx
+++ b/apps/web/src/agent/AgentInsightWorkbench.tsx
@@ -2,6 +2,7 @@ import type { TeamRole } from '../../../../packages/schemas/src/index.js'
 import type { RolePrivateState } from './agentSessionTypes.js'
 import { AgentInsightWorkbenchView } from './AgentInsightWorkbenchView'
 import './AgentInsightWorkbench.css'
+import './AgentInsightWorkbenchDrawer.css'
 
 type AgentInsightWorkbenchProps = {
   role: TeamRole

--- a/apps/web/src/agent/AgentInsightWorkbenchDrawer.css
+++ b/apps/web/src/agent/AgentInsightWorkbenchDrawer.css
@@ -1,0 +1,85 @@
+.insight-v6-tabs {
+  min-width: min(460px, 100%);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.insight-v6-equipped-context {
+  min-width: 0;
+  padding: 9px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  border: 1px solid rgba(247, 184, 75, 0.16);
+  border-radius: 7px;
+  background: rgba(247, 184, 75, 0.045);
+}
+
+.insight-v6-equipped-context span {
+  max-width: 140px;
+  padding: 4px 7px;
+  overflow: hidden;
+  border: 1px solid rgba(238, 242, 247, 0.1);
+  border-radius: 999px;
+  color: var(--category-color);
+  background: rgba(4, 8, 11, 0.62);
+  font-size: 0.64rem;
+  font-weight: 950;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.insight-v6-tree-list {
+  max-height: clamp(260px, 34vh, 520px);
+  margin: 8px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+  overflow: auto;
+  list-style: none;
+  scrollbar-color: rgba(143, 208, 255, 0.46) rgba(4, 7, 10, 0.52);
+  scrollbar-width: thin;
+}
+
+.insight-v6-tree-row {
+  min-width: 0;
+  padding: 8px 10px;
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(112px, 0.55fr) minmax(140px, 0.7fr);
+  gap: 8px;
+  align-items: center;
+  border: 1px solid rgba(238, 242, 247, 0.09);
+  border-radius: 7px;
+  background:
+    linear-gradient(180deg, rgba(238, 242, 247, 0.036), rgba(238, 242, 247, 0.01)),
+    rgba(5, 9, 12, 0.62);
+  box-shadow: inset 3px 0 0 var(--category-color);
+}
+
+.insight-v6-tree-row strong,
+.insight-v6-tree-row span,
+.insight-v6-tree-row small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.insight-v6-tree-row strong {
+  color: #eef2f3;
+  font-size: 0.84rem;
+}
+
+.insight-v6-tree-row span,
+.insight-v6-tree-row small {
+  color: #aeb7c1;
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+@media (max-width: 900px) {
+  .insight-v6-tabs,
+  .insight-v6-tree-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/apps/web/src/agent/AgentInsightWorkbenchReadouts.ts
+++ b/apps/web/src/agent/AgentInsightWorkbenchReadouts.ts
@@ -9,7 +9,7 @@ import { canonicalPartIdFromCompact } from '../../../../packages/sim/src/compact
 import { formatCatalogLabel } from '../../../../packages/catalog/src/index.js'
 import type { ConfirmedLoadoutView, RolePrivateState } from './agentSessionTypes.js'
 
-export type DrawerTab = 'equipped' | 'store'
+export type DrawerTab = 'equipped' | 'store' | 'tree'
 export type CategoryKey = 'structure' | 'weapon' | 'defense' | 'mobility' | 'utility' | 'style' | 'other'
 export type PartReadoutTone = 'neutral' | 'ok' | 'warning'
 
@@ -18,6 +18,7 @@ export type LoadoutPartReadout = {
   detail: string
   instanceId: string
   name: string
+  parentId?: string
   source: string
   stats: string
   status: string
@@ -74,30 +75,36 @@ export function createBuildSnapshot(
   storeOffers: CatalogPartReadout[],
   foundationParts: CatalogPartReadout[],
 ): BuildSnapshot {
-  const compactSummary = state?.gameMaster?.build?.bot.summary
+  const compactBuild = state?.gameMaster?.build
+  const compactSummary = compactBuild?.bot.summary
   const remaining = readFiniteNumber(
-    state?.gameMaster?.build?.budget.parts ?? state?.gameMaster?.resources?.partLimitRemaining,
+    compactBuild?.budget.parts ?? state?.gameMaster?.resources?.partLimitRemaining,
   )
-  const purchased = parts.filter((part) => part.source !== 'System' && part.status !== 'Core').length
+  const rowPurchased = parts.filter((part) => part.source !== 'System' && part.status !== 'Core').length
+  const purchased = typeof remaining === 'number'
+    ? Math.max(0, LOADOUT_PART_LIMIT - remaining)
+    : rowPurchased
   const categories = createCategorySummary(parts)
   const dominant = categories
     .filter((category) => category.count > 0)
     .sort((left, right) => right.count - left.count)[0]
+  const roundOfferCount = compactBuild?.store?.offers.length ?? storeOffers.length
+  const foundationCount = compactBuild?.store?.foundation.length ?? foundationParts.length
 
   return {
     armor: compactSummary ? String(compactSummary.armor) : '—',
     categories,
     dominant,
-    foundationCount: foundationParts.length,
+    foundationCount,
     hp: compactSummary ? `${compactSummary.hp}/${compactSummary.maxHp}` : '—',
-    limit: Math.max(LOADOUT_PART_LIMIT, purchased + (remaining ?? 0), purchased),
+    limit: LOADOUT_PART_LIMIT,
     mapParts: parts.filter((part) => part.source !== 'System' && part.status !== 'Core'),
     mass: compactSummary ? formatPartMass(compactSummary.mass) : '—',
     purchased,
     remaining,
-    rows: parts.length,
-    storeActive: storeOffers.length > 0 || foundationParts.length > 0,
-    storeOffers: storeOffers.length,
+    rows: compactBuild?.bot.parts.length ?? parts.length,
+    storeActive: roundOfferCount > 0 || foundationCount > 0,
+    storeOffers: roundOfferCount,
     utility: compactSummary ? String(compactSummary.utility.length) : '—',
     weapons: compactSummary ? String(compactSummary.weapons.length) : '—',
   }
@@ -107,6 +114,10 @@ export function createCategorySummary(parts: LoadoutPartReadout[]): CategorySumm
   const counts = new Map<CategoryKey, number>(CATEGORY_ORDER.map((category) => [category.key, 0]))
 
   for (const part of parts) {
+    if (part.source === 'System' || part.status === 'Core') {
+      continue
+    }
+
     const key = normalizeCategory(part.category)
     counts.set(key, (counts.get(key) ?? 0) + 1)
   }
@@ -248,12 +259,14 @@ function machinePartReadout(
     Boolean(machine.runtime?.detachedInstanceIds?.includes(part.instanceId)),
     Boolean(machine.runtime?.disabledInstanceIds?.includes(part.instanceId)),
   )
+  const parentId = machine.attachments.find((attachment) => attachment.childInstanceId === part.instanceId)?.parentInstanceId
 
   return {
     category: definition ? formatCatalogLabel(definition.category) : part.source === 'system_core' ? 'Core' : 'Unknown',
     detail: formatPartDetail(definition, health),
     instanceId: part.instanceId,
     name: definition?.displayName ?? (part.source === 'system_core' ? 'Machine Core' : formatCatalogLabel(part.definitionId)),
+    ...(parentId ? { parentId } : {}),
     source: part.source === 'system_core' ? 'System' : 'Catalog',
     stats: formatPartStats(definition),
     status: status.label,
@@ -274,6 +287,7 @@ function blueprintBlockReadout(
     detail: formatPartDetail(definition, health),
     instanceId: block.id,
     name: definition?.displayName ?? formatCatalogLabel(block.partId),
+    ...(block.parentInstanceId ? { parentId: block.parentInstanceId } : {}),
     source: 'Blueprint',
     stats: formatPartStats(definition),
     status: status.label,

--- a/apps/web/src/agent/AgentInsightWorkbenchView.tsx
+++ b/apps/web/src/agent/AgentInsightWorkbenchView.tsx
@@ -49,8 +49,8 @@ export function AgentInsightWorkbenchView({ role, roleState }: Props) {
       <div className="plan-metric-strip insight-v6-status-strip" aria-label="Agent state summary">
         <PlanMetric label="Phase" value={formatLabel(roleState?.phase ?? 'not_loaded')} />
         <PlanMetric label="Loadout" tone={submitted ? 'ok' : undefined} value={submissionLabel} />
-        <PlanMetric label="Blueprint" value={blueprint ? `${blueprint.blocks.length} blocks` : 'No blueprint'} />
-        <PlanMetric label="Parts" value={`${snapshot.purchased}/${snapshot.limit}`} />
+        <PlanMetric label="Build" value={`${snapshot.purchased}/${snapshot.limit} parts`} />
+        <PlanMetric label="Store" tone={snapshot.storeActive ? 'ok' : undefined} value={snapshot.storeActive ? `${snapshot.storeOffers} offers` : 'No store'} />
         <PlanMetric
           label={combatPacket ? 'Combat plan' : roleState?.phase === 'combat_turn' ? 'Board actions' : 'Actions'}
           tone={combatPacket && !combatPacket.submitted ? 'ok' : legalActions.length > 0 ? 'ok' : undefined}
@@ -88,26 +88,33 @@ export function AgentInsightWorkbenchView({ role, roleState }: Props) {
             <div className="insight-v6-drawer-header">
               <div>
                 <SectionTitle id="detail-drawer-heading" title="Part explorer" />
-                <p>Read-only drawer for installed parts and the current store packet.</p>
+                <p>Read-only drawer for installed parts, machine tree, and the current store packet.</p>
               </div>
               <PartExplorerTabs
                 activeTab={drawerTab}
+                partCount={loadoutParts.length}
+                rowCount={snapshot.rows}
                 setActiveTab={setDrawerTab}
-                storeCount={storeOffers.length + foundationParts.length}
+                storeCount={storeOffers.length + foundationParts.length + inventoryParts.length}
                 storeActive={snapshot.storeActive}
               />
             </div>
 
             {drawerTab === 'equipped' ? (
               <EquippedPartsDrawer parts={loadoutParts} snapshot={snapshot} />
-            ) : (
+            ) : null}
+            {drawerTab === 'store' ? (
               <StoreDrawer
                 foundationParts={foundationParts}
                 inventoryParts={inventoryParts}
+                loadoutParts={loadoutParts}
                 snapshot={snapshot}
                 storeOffers={storeOffers}
               />
-            )}
+            ) : null}
+            {drawerTab === 'tree' ? (
+              <TreeDrawer parts={loadoutParts} />
+            ) : null}
           </section>
         </>
       ) : null}
@@ -184,11 +191,12 @@ function PartMap({ snapshot }: { snapshot: BuildSnapshot }) {
   return <div className="insight-v6-part-map" aria-label="Installed part density map">{cells.map((part, index) => <span className={part ? `category-${normalizeCategory(part.category)}` : 'category-empty'} key={part?.instanceId ?? `empty.${index}`} title={part ? `${part.name} · ${part.instanceId}` : `Empty slot ${index + 1}`} />)}</div>
 }
 
-function PartExplorerTabs({ activeTab, setActiveTab, storeActive, storeCount }: { activeTab: DrawerTab; setActiveTab: (tab: DrawerTab) => void; storeActive: boolean; storeCount: number }) {
+function PartExplorerTabs({ activeTab, partCount, rowCount, setActiveTab, storeActive, storeCount }: { activeTab: DrawerTab; partCount: number; rowCount: number; setActiveTab: (tab: DrawerTab) => void; storeActive: boolean; storeCount: number }) {
   return (
     <div className="insight-v6-tabs" role="tablist" aria-label="Part explorer view">
-      <button className={activeTab === 'equipped' ? 'is-active' : ''} onClick={() => setActiveTab('equipped')} role="tab" type="button" aria-selected={activeTab === 'equipped'}>Equipped Parts</button>
+      <button className={activeTab === 'equipped' ? 'is-active' : ''} onClick={() => setActiveTab('equipped')} role="tab" type="button" aria-selected={activeTab === 'equipped'}>Equipped Parts<span>{partCount}</span></button>
       <button className={activeTab === 'store' ? 'is-active' : ''} onClick={() => setActiveTab('store')} role="tab" type="button" aria-selected={activeTab === 'store'}>Store{storeActive ? <span>{storeCount}</span> : null}</button>
+      <button className={activeTab === 'tree' ? 'is-active' : ''} onClick={() => setActiveTab('tree')} role="tab" type="button" aria-selected={activeTab === 'tree'}>Tree View<span>{rowCount}</span></button>
     </div>
   )
 }
@@ -204,18 +212,57 @@ function EquippedPartsDrawer({ parts, snapshot }: { parts: LoadoutPartReadout[];
   )
 }
 
-function StoreDrawer({ foundationParts, inventoryParts, snapshot, storeOffers }: { foundationParts: CatalogPartReadout[]; inventoryParts: CatalogPartReadout[]; snapshot: BuildSnapshot; storeOffers: CatalogPartReadout[] }) {
+function StoreDrawer({ foundationParts, inventoryParts, loadoutParts, snapshot, storeOffers }: { foundationParts: CatalogPartReadout[]; inventoryParts: CatalogPartReadout[]; loadoutParts: LoadoutPartReadout[]; snapshot: BuildSnapshot; storeOffers: CatalogPartReadout[] }) {
   return (
     <div className="insight-v6-drawer-body insight-v6-store-body" role="tabpanel">
       <div className="insight-v6-store-context"><strong>Current build context</strong><span>{snapshot.purchased}/{snapshot.limit} purchased</span><span>{snapshot.remaining === undefined ? 'cap unknown' : `${snapshot.remaining} cap remaining`}</span><span>{snapshot.storeOffers} round offers</span></div>
+      <div className="insight-v6-equipped-context" aria-label="Currently equipped context">
+        {loadoutParts.slice(0, 8).map((part) => <span className={`category-${normalizeCategory(part.category)}`} key={part.instanceId}>{part.name}</span>)}
+      </div>
       <div className="insight-v6-store-grid"><CatalogPartList emptyText="No round store offers are loaded for this role state." parts={storeOffers} title="Round offers" /><CatalogPartList emptyText="No foundation templates are loaded." parts={foundationParts} title="Foundation templates" /><CatalogPartList emptyText="No owned catalog parts are in inventory." parts={inventoryParts} title="Owned inventory" /></div>
       <p className="insight-v6-readonly-note">Store is visible for humans, but buying, mounting, moving, and confirming remain agent actions.</p>
     </div>
   )
 }
 
+function TreeDrawer({ parts }: { parts: LoadoutPartReadout[] }) {
+  const depthById = createDepthByPartId(parts)
+  return (
+    <div className="insight-v6-drawer-body" role="tabpanel">
+      {parts.length > 0
+        ? <ol className="insight-v6-tree-list">{parts.map((part) => <li className={`insight-v6-tree-row category-${normalizeCategory(part.category)}`} key={part.instanceId} style={{ paddingLeft: `${10 + (depthById.get(part.instanceId) ?? 0) * 16}px` }}><strong>{part.name}</strong><span>{part.instanceId}</span><small>parent: {part.parentId ?? 'root'}</small></li>)}</ol>
+        : <p className="agent-empty">No mounted part tree is available.</p>}
+    </div>
+  )
+}
+
 function CatalogPartList({ emptyText, parts, title }: { emptyText: string; parts: CatalogPartReadout[]; title: string }) {
   return <div className="catalog-part-block insight-v6-catalog-block"><strong>{title}</strong>{parts.length > 0 ? <ul className="catalog-part-list insight-v6-catalog-list">{parts.map((part) => <li key={part.id}><div><span>{part.category}</span><strong>{part.name}</strong><small>{part.detail}</small></div><em>{part.quantity ? `x${part.quantity}` : part.status}</em></li>)}</ul> : <p className="agent-empty">{emptyText}</p>}</div>
+}
+
+function createDepthByPartId(parts: LoadoutPartReadout[]): Map<string, number> {
+  const partsById = new Map(parts.map((part) => [part.instanceId, part]))
+  const depths = new Map<string, number>()
+  const depthFor = (part: LoadoutPartReadout, seen = new Set<string>()): number => {
+    const cached = depths.get(part.instanceId)
+    if (typeof cached === 'number') return cached
+    if (!part.parentId || seen.has(part.parentId)) {
+      depths.set(part.instanceId, 0)
+      return 0
+    }
+    const parent = partsById.get(part.parentId)
+    if (!parent) {
+      depths.set(part.instanceId, 1)
+      return 1
+    }
+    const nextSeen = new Set(seen)
+    nextSeen.add(part.instanceId)
+    const depth = depthFor(parent, nextSeen) + 1
+    depths.set(part.instanceId, depth)
+    return depth
+  }
+  for (const part of parts) depthFor(part)
+  return depths
 }
 
 function createInsightSubtitle(roleState: RolePrivateState | null, loadout: ConfirmedLoadoutView | null, identity: ReturnType<typeof resolveTeamIdentity> | null): string {


### PR DESCRIPTION
## Summary
- Keeps the current split AgentInsightWorkbench refactor and layers on the cockpit changes from the V6 direction.
- Adds a three-tab read-only drawer: Equipped Parts, Store, and Tree View.
- Surfaces store state in the top metric strip and store drawer while preserving the assembly bay + build snapshot layout.
- Uses compact build budget/store data when available for purchased count, remaining cap, offers, and rows.
- Tracks parent IDs for machine/blueprint rows so the tree view can show parent-child relationships.

## Intent
Humans can inspect the current machine, the current store packet, and the mounted part tree without seeing buy/edit/submit controls. The right-side snapshot stays summary-first; dense rows stay in the bottom drawer.

## Testing
- Not run locally. Changes were made through the GitHub connector; local clone/build was unavailable in this environment.