### PR TITLE
Prune obsolete champion-loop contracts

### DIFF
--- a/apps/web/src/agent/agentSessionTypes.ts
+++ b/apps/web/src/agent/agentSessionTypes.ts
@@ -2,7 +2,6 @@ import type {
   AgentChatMessageRequest,
   ArenaConfig,
   BotBlueprint,
-  ChampionContinuationSave,
   ChampionRecord,
   CombatBotSnapshot,
   CombatBudget,
@@ -219,22 +218,6 @@ export type RoleResetResponse = {
 }
 
 export type AdvanceRoundResponse = {
-  publicState: PublicSessionState
-}
-
-export type SaveCompletedSessionResponse = {
-  save: ChampionContinuationSave
-  publicState: PublicSessionState
-}
-
-export type ContinueChampionSessionResponse = {
-  save: ChampionContinuationSave
-  nextSessionId: string
-  nextSession: CreateSessionResponse
-  publicState: PublicSessionState
-}
-
-export type QuitCompletedSessionResponse = {
   publicState: PublicSessionState
 }
 

--- a/apps/worker/src/sessionLegacyContracts.ts
+++ b/apps/worker/src/sessionLegacyContracts.ts
@@ -2,7 +2,6 @@ import type {
   AgentChatMessageRequest,
   ArenaConfig,
   BotBlueprint,
-  ChampionContinuationSave,
   ChampionRecord,
   CombatBotSnapshot,
   CombatTurnSnapshot,
@@ -56,9 +55,6 @@ export type LegacySessionLogEvent = {
     | 'round_advanced'
     | 'economy_applied'
     | 'session_completed'
-    | 'session_saved'
-    | 'session_continued'
-    | 'session_quit'
   message: string
 }
 
@@ -241,22 +237,6 @@ export type LegacyPostFightReflectionResponse = {
 export type LegacyPostFightReflectionPostRequest = PostFightAgentReflection
 
 export type LegacyAdvanceRoundResponse = {
-  publicState: LegacyPublicSessionState
-}
-
-export type LegacySaveCompletedSessionResponse = {
-  save: ChampionContinuationSave
-  publicState: LegacyPublicSessionState
-}
-
-export type LegacyContinueChampionSessionResponse = {
-  save: ChampionContinuationSave
-  nextSessionId: string
-  nextSession: LegacyCreateSessionResponse
-  publicState: LegacyPublicSessionState
-}
-
-export type LegacyQuitCompletedSessionResponse = {
   publicState: LegacyPublicSessionState
 }
 

--- a/packages/schemas/src/relay.ts
+++ b/packages/schemas/src/relay.ts
@@ -2,7 +2,6 @@ import type {
   AgentChatMessageRequest,
   ArenaConfig,
   BotBlueprint,
-  ChampionContinuationSave,
   ChampionRecord,
   CombatRoundPlanSubmission,
   GameMasterActionSubmission,
@@ -69,9 +68,6 @@ export type SessionLogEvent = {
     | 'economy_applied'
     | 'reflection_submitted'
     | 'session_completed'
-    | 'session_saved'
-    | 'session_continued'
-    | 'session_quit'
   message: string
 }
 
@@ -145,22 +141,6 @@ export type CreateSessionResponse = {
   phase: SessionPhase
   invites: RoleInvite[]
   refereeToken: string
-  publicState: PublicSessionState
-}
-
-export type SaveCompletedSessionResponse = {
-  save: ChampionContinuationSave
-  publicState: PublicSessionState
-}
-
-export type ContinueChampionSessionResponse = {
-  save: ChampionContinuationSave
-  nextSessionId: string
-  nextSession: CreateSessionResponse
-  publicState: PublicSessionState
-}
-
-export type QuitCompletedSessionResponse = {
   publicState: PublicSessionState
 }
 


### PR DESCRIPTION
## Summary
- removes obsolete save/continue/quit champion-loop response contracts from the public relay schema
- removes the matching stale agent-session and worker legacy response aliases
- removes dead session log event variants for the retired champion-loop endpoints

## Audit notes
- Kept `sessionLegacyContracts.ts` itself because the worker still imports active live shapes from it (`LegacyCreateSessionResponse`, `LegacyAgentBootstrapResponse`, role state/chat/replay/reflection contracts).
- Kept the active player-key bootstrap compatibility path (`sessionBootstrapLegacy.ts`) because `/sessions/:sessionId/roles/:role/bootstrap` and `SessionCoordinator.bootstrapRole` still call it.
- No runtime assets were removed; the asset references I found are catalog visual-reference metadata and capture-tool paths rather than shipped imported assets.
- Test files were reviewed, but I did not delete whole test files because the remaining route tests still cover the current public contract and renderer ownership boundaries. The obsolete public contract residue removed here was in source type surfaces, not standalone test-only files.

## Validation
- Not run locally; the repo could not be cloned in this environment because DNS/network access to GitHub is unavailable from the container. The branch is based on current `main` and the diff is limited to type-only contract cleanup.